### PR TITLE
Only return applications that are active.

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,7 +36,7 @@ export function Init({ workspaceId, apiToken, verbose = false }: RankgunInitConf
 
         if (applications.forms) {
             // only return applications that are active.
-            return applications.forms?.filter((application) => application.isActive );
+            return applications.forms.filter((application) => application.isActive);
         } else {
             notifyError(player, "Couldn't load applications", "The centre failed to load applications. Try again later")
             return [];

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -35,8 +35,8 @@ export function Init({ workspaceId, apiToken, verbose = false }: RankgunInitConf
         const applications = getApplicationList(apiToken);
 
         if (applications.forms) {
-            // only return applications that are active and public
-            return applications.forms?.filter((application) => application.isActive && !application.isPublic);
+            // only return applications that are active.
+            return applications.forms?.filter((application) => application.isActive );
         } else {
             notifyError(player, "Couldn't load applications", "The centre failed to load applications. Try again later")
             return [];


### PR DESCRIPTION
Only return applications that are active, isPublic is the incorrect flag to use, API documentation should also be updated accordingly. 