### PR TITLE
+ Telemetry module

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,12 @@ jobs:
         run: cargo install rojo --version 7.7.0-rc.1
 
       - name: Install dependencies
-        run: npm i 
+        run: npm i
 
-      - name: Compile Roblox Ts 
+      - name: Stamp release version
+        run: echo "export const CENTRE_VERSION = \"${{ github.event.release.tag_name }}\";" > src/version.ts
+
+      - name: Compile Roblox Ts
         run: npm run compile
       
       - name: Build  

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,22 @@ RankgunModule.Init({
 
 Before using, you must enable a few Experience Settings - namely, Security -> Allow HTTP Requests and Allow Loading Third Party Assets. You may also wish to enable DataStores in Studio to allow for playtesting.
 
+## Telemetry
+
+So that RankGun can support self-hosted centres, the centre reports lightweight, aggregate
+operational telemetry to RankGun's API (`/api/telemetry`) using the same API key it already
+uses for ranking. This lets RankGun see whether a centre is online, what build it's running,
+how applications are converting, and where API calls are failing.
+
+It sends only instance-level facts (centre version, place/universe/server id, environment,
+current player count, uptime) and a small set of events: `centre_boot`, `heartbeat`,
+`forms_loaded`, `application_started`, `application_submitted`, `rank_result`, and
+`api_error` (HTTP status + short error code only).
+
+**No end-user data is ever collected** — no UserIds, usernames, question text, submitted
+answers, or raw error bodies. All requests are best-effort and run on a background thread, so
+telemetry never affects gameplay. See `src/server/telemetry.ts`.
+
 ## Development
 
 The client's GUI is rendered with react-lua components; it replicates using a LocalScript parented to the PlayerGui. We use Remo for remote declaration and to allow for full types.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ import { remotes } from "shared/remotes";
 import { Application } from "shared/types";
 
 import { getApplication, getApplicationList, setRank } from "./rankgunApi";
+import { Telemetry } from "./telemetry";
 
 const CooldownDatastore = DataStoreService.GetDataStore("rankgun-application-cooldown");
 
@@ -28,14 +29,19 @@ export function Init({ workspaceId, apiToken }: { workspaceId: string, apiToken:
     print("[Rankgun] Initialising remote listeners");
 
     BannerNotify.InitServer();
+    Telemetry.init({ workspaceId, apiToken });
 
     // set up remote listeners
-    remotes.getCentreData.onRequest((player) => { 
+    remotes.getCentreData.onRequest((player) => {
         const applications = getApplicationList(apiToken);
 
         if (applications.forms) {
             // only return applications that are active and public
-            return applications.forms?.filter((application) => application.isActive && !application.isPublic);
+            const visible = applications.forms.filter(
+                (application) => application.isActive && !application.isPublic,
+            );
+            Telemetry.track("forms_loaded", { formCount: visible.size() });
+            return visible;
         } else {
             notifyError(player, "Couldn't load applications", "The centre failed to load applications. Try again later")
             return [];
@@ -64,7 +70,7 @@ export function Init({ workspaceId, apiToken }: { workspaceId: string, apiToken:
                 const answers = [ ...question.incorrectAnswers, question.correctAnswer ];
                 random.Shuffle(answers);
 
-                return { 
+                return {
                     id: question.id,
                     order: question.order,
                     questionText: question.questionText,
@@ -75,6 +81,7 @@ export function Init({ workspaceId, apiToken }: { workspaceId: string, apiToken:
                 }
             });
 
+            Telemetry.track("application_started", { applicationId });
             return questions;
         } else {
             notifyError(player, "Couldn't load application list", "Rankgun couldn't fetch a list of applications.")
@@ -107,13 +114,29 @@ export function Init({ workspaceId, apiToken }: { workspaceId: string, apiToken:
             const score = (correctAnswers / application.questions.size());
             const hasPassed = score >= (application.passPercentage / 100);
 
+            Telemetry.track("application_submitted", {
+                applicationId,
+                passed: hasPassed,
+                score,
+                targetRankId: application.targetRankId,
+            });
+
             // rank the user only if they have passed
             if (hasPassed) {
                 const rankResponse = setRank(player, application.targetRankId, workspaceId, apiToken);
-                if (!rankResponse || rankResponse.StatusCode !== 200) {
+                const ranked = rankResponse !== undefined && rankResponse.StatusCode === 200;
+
+                Telemetry.track("rank_result", {
+                    applicationId,
+                    targetRankId: application.targetRankId,
+                    success: ranked,
+                    httpStatus: rankResponse ? rankResponse.StatusCode : undefined,
+                });
+
+                if (!ranked) {
                     warn("[Rankgun] Failed to rank eligible user");
-                    if (rankResponse.Body) warn(rankResponse.Body);
-                    
+                    if (rankResponse && rankResponse.Body) warn(rankResponse.Body);
+
                     return { passed: false, score, rankName: application.targetRankName, errorMessage: "You passed, but Rankgun couldn't give you the target rank." };
                 }
             }

--- a/src/server/rankgunApi.ts
+++ b/src/server/rankgunApi.ts
@@ -1,7 +1,21 @@
 import { HttpService } from "@rbxts/services";
 import { ApplicationResponse, ApplicationsResults } from "shared/types";
 
+import { Telemetry } from "./telemetry";
+
 const BASE_URL = "https://api.rankgun.works";
+
+/** Report a non-200 response as an api_error event (status + short code only). */
+function reportError(call: string, statusCode: number, body: object) {
+    if (statusCode === 200) {
+        return;
+    }
+    Telemetry.track("api_error", {
+        call,
+        httpStatus: statusCode,
+        code: (body as { code?: string }).code,
+    });
+}
 
 function httpRequest(path: string, apiToken: string, method: "GET" | "POST", body?: string): { Body: object, StatusCode: number } {
     const request = HttpService.RequestAsync({
@@ -28,11 +42,13 @@ function httpRequest(path: string, apiToken: string, method: "GET" | "POST", bod
 
 export function getApplicationList(apiToken: string): ApplicationsResults {
     const apiResponse = httpRequest(`/api/applications`, apiToken, "GET");
+    reportError("list", apiResponse.StatusCode, apiResponse.Body);
     return apiResponse.Body as ApplicationsResults;
 }
 
 export function getApplication(apiToken: string, applicationId: string): ApplicationResponse {
     const apiResponse = httpRequest(`/api/applications/forms/${applicationId}`, apiToken, "GET");
+    reportError("get", apiResponse.StatusCode, apiResponse.Body);
     return apiResponse.Body as ApplicationResponse;
 }
 
@@ -45,5 +61,6 @@ export function setRank(player: Player, rank: number, workspaceId: string, apiTo
             workspaceId: workspaceId,
         }),
     );
+    reportError("setrank", apiResponse.StatusCode, apiResponse.Body);
     return apiResponse;
 }

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -1,0 +1,126 @@
+import { HttpService, Players, RunService } from "@rbxts/services";
+
+import { CENTRE_VERSION } from "../version";
+
+/**
+ * Lightweight, fire-and-forget operational telemetry for the application centre.
+ *
+ * Because centres are self-hosted, RankGun otherwise has no remote visibility
+ * into whether a centre is running, on what build, or where it's failing. This
+ * module reports aggregate operational events to RankGun's `/api/telemetry`
+ * endpoint using the same `x-api-key` the centre already holds.
+ *
+ * It never sends end-user PII — no UserIds, usernames, question text, answers,
+ * or raw error bodies. Only instance-level facts and short status/error codes.
+ * All network calls are wrapped in `pcall` and dispatched on a separate thread,
+ * so telemetry can never block or break gameplay.
+ */
+
+const BASE_URL = "https://api.rankgun.works";
+const CENTRE_TYPE = "application";
+const FLUSH_INTERVAL = 30; // seconds between batched flushes
+const HEARTBEAT_INTERVAL = 120; // seconds between liveness heartbeats
+const MAX_QUEUE = 20; // flush early once this many events are queued
+
+export type TelemetryProps = {
+	applicationId?: string;
+	passed?: boolean;
+	score?: number;
+	targetRankId?: number;
+	success?: boolean;
+	httpStatus?: number;
+	call?: string;
+	code?: string;
+	formCount?: number;
+};
+
+type QueuedEvent = { type: string; t: number; props?: TelemetryProps };
+
+let apiToken = "";
+let started = false;
+let startClock = 0;
+let queue: QueuedEvent[] = [];
+
+function environment(): "live" | "studio" {
+	return RunService.IsStudio() ? "studio" : "live";
+}
+
+/** Build the current envelope and send any queued events on a separate thread. */
+function flush() {
+	if (queue.size() === 0) {
+		return;
+	}
+
+	const events = queue;
+	queue = [];
+
+	const payload = {
+		centreType: CENTRE_TYPE,
+		centreVersion: CENTRE_VERSION,
+		placeId: game.PlaceId,
+		universeId: game.GameId,
+		jobId: game.JobId,
+		environment: environment(),
+		playerCount: Players.GetPlayers().size(),
+		uptimeSec: math.floor(os.clock() - startClock),
+		events,
+	};
+
+	task.spawn(() => {
+		pcall(() => {
+			HttpService.RequestAsync({
+				Url: `${BASE_URL}/api/telemetry`,
+				Method: "POST",
+				Headers: {
+					"Content-Type": "application/json",
+					"x-api-key": apiToken,
+				},
+				Body: HttpService.JSONEncode(payload),
+			});
+		});
+	});
+}
+
+/** Queue an event; flushes early once the queue is full. */
+function track(eventType: string, props?: TelemetryProps) {
+	if (!started) {
+		return;
+	}
+
+	queue.push({ type: eventType, t: os.time(), props });
+
+	if (queue.size() >= MAX_QUEUE) {
+		flush();
+	}
+}
+
+/** Start telemetry: emit a boot event and run the flush + heartbeat loops. */
+function init(config: { workspaceId: string; apiToken: string }) {
+	if (started) {
+		return;
+	}
+
+	apiToken = config.apiToken;
+	startClock = os.clock();
+	started = true;
+
+	track("centre_boot");
+	flush();
+
+	task.spawn(() => {
+		while (true) {
+			task.wait(FLUSH_INTERVAL);
+			flush();
+		}
+	});
+
+	task.spawn(() => {
+		while (true) {
+			task.wait(HEARTBEAT_INTERVAL);
+			track("heartbeat");
+			flush();
+		}
+	});
+}
+
+export const Telemetry = { init, track };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+// The release workflow (.github/workflows/publish.yml) overwrites this file with
+// the published release tag before compiling. Local and Studio builds report "dev".
+export const CENTRE_VERSION = "dev";


### PR DESCRIPTION
Record telemetry & send back to rankgun for analysis: 

- application_submitted — { applicationId, passed, score, targetRankId }
- rank_result — { applicationId, targetRankId, success, httpStatus } (surfaces the silent "passed but rank grant failed" case)
- api_error — { call, httpStatus, code } (emitted on any non-200 from the RankGun API)


>  No PPI recorded. 